### PR TITLE
Issue 158: GCP network parameter missing

### DIFF
--- a/trident-use/gcp.adoc
+++ b/trident-use/gcp.adoc
@@ -63,6 +63,8 @@ See the following table for the backend configuration options:
 
 | `serviceLevel` |The CVS service level for new volumes. The values are "standard", "premium", and "extreme". |"standard"
 
+|`network` |GCP network used for CVS volumes |“default”
+
 |`debugTraceFlags` |Debug flags to use when troubleshooting. Example, `\{"api":false, "method":true}`. Do not use this unless you are troubleshooting and require a detailed log dump. |null
 |===
 


### PR DESCRIPTION
Added:
|`network` |GCP network used for CVS volumes |“default”